### PR TITLE
restore vgprDbg value using hidden buffer

### DIFF
--- a/src/code_object_swapper.cpp
+++ b/src/code_object_swapper.cpp
@@ -70,8 +70,9 @@ bool CodeObjectSwapper::run_external_command(const std::string& cmd, const Debug
 
     if (auto buf_addr = debug_buffer.gpu_buffer_address())
     {
-        environment["ASM_DBG_BUF_SIZE"] = std::to_string(debug_buffer.size());
+        environment["ASM_DBG_BUF_SIZE"] = std::to_string(debug_buffer.debug_size());
         environment["ASM_DBG_BUF_ADDR"] = std::to_string(*buf_addr);
+        environment["ASM_HID_BUF_ADDR"] = std::to_string(*buf_addr + debug_buffer.debug_size());
     }
     else
     {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -64,6 +64,7 @@ Config::Config()
 
         // Optional
         _debug_buffer_size = config->get_qualified_as<uint64_t>("debug-buffer.size").value_or(0);
+        _debug_hidden_buffer_size = config->get_qualified_as<uint64_t>("debug-buffer.hidden-size").value_or(0);
         _debug_buffer_dump_file = config->get_qualified_as<std::string>("debug-buffer.dump-file").value_or("");
 
         if (auto swap_configs = config->get_table_array("code-object-swap"))

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -10,6 +10,7 @@ class Config
 private:
     std::string _agent_log_file;
     uint64_t _debug_buffer_size;
+    uint64_t _debug_hidden_buffer_size;
     std::string _debug_buffer_dump_file;
     std::string _code_object_log_file;
     std::string _code_object_dump_dir;
@@ -19,6 +20,7 @@ public:
     Config();
     const std::string& agent_log_file() const { return _agent_log_file; }
     uint64_t debug_buffer_size() const { return _debug_buffer_size; }
+    uint64_t debug_hidden_buffer_size() const { return _debug_hidden_buffer_size; }
     const std::string& debug_buffer_dump_file() const { return _debug_buffer_dump_file; }
     const std::string& code_object_log_file() const { return _code_object_log_file; }
     const std::string& code_object_dump_dir() const { return _code_object_dump_dir; }

--- a/src/debug_agent.cpp
+++ b/src/debug_agent.cpp
@@ -93,7 +93,7 @@ template <typename T>
 std::optional<T> DebugAgent::load_swapped_code_object(hsa_agent_t agent, RecordedCodeObject& co)
 {
     if (!_debug_buffer)
-        _debug_buffer = std::make_unique<DebugBuffer>(agent, *_logger, _config->debug_buffer_size());
+        _debug_buffer = std::make_unique<DebugBuffer>(agent, *_logger, _config->debug_buffer_size(), _config->debug_hidden_buffer_size());
     if (auto swap = _co_swapper->try_swap(co, *_debug_buffer, agent))
     {
         T loaded_replacement;

--- a/src/debug_buffer.cpp
+++ b/src/debug_buffer.cpp
@@ -2,10 +2,10 @@
 
 using namespace agent;
 
-DebugBuffer::DebugBuffer(hsa_agent_t agent, AgentLogger& logger, uint64_t size)
-    : _size(size), _gpu_ptr(nullptr), _host_ptr(nullptr)
+DebugBuffer::DebugBuffer(hsa_agent_t agent, AgentLogger& logger, uint64_t buffer_size, uint64_t hidden_size)
+    : _size(buffer_size + hidden_size), _hidden_size(hidden_size), _gpu_ptr(nullptr), _host_ptr(nullptr)
 {
-    if (size == 0)
+    if (_size == 0)
     {
         logger.warning("Debug buffer will not be allocated (debug buffer set is set to 0)");
         return;
@@ -23,13 +23,13 @@ DebugBuffer::DebugBuffer(hsa_agent_t agent, AgentLogger& logger, uint64_t size)
         return;
     }
 
-    status = hsa_memory_allocate(_gpu_region, size, &_gpu_ptr);
+    status = hsa_memory_allocate(_gpu_region, _size, &_gpu_ptr);
     if (status != HSA_STATUS_SUCCESS)
     {
         logger.hsa_error("Unable to allocate GPU memory for debug buffer", status, "hsa_memory_allocate");
         return;
     }
-    status = hsa_memory_allocate(_host_region, size, &_host_ptr);
+    status = hsa_memory_allocate(_host_region, _size, &_host_ptr);
     if (status != HSA_STATUS_SUCCESS)
     {
         logger.hsa_error("Unable to allocate host memory for debug buffer", status, "hsa_memory_allocate");
@@ -37,7 +37,7 @@ DebugBuffer::DebugBuffer(hsa_agent_t agent, AgentLogger& logger, uint64_t size)
     }
 
     std::ostringstream msg;
-    msg << "Allocated debug buffer of size " << size << " at " << _gpu_ptr;
+    msg << "Allocated debug buffer of size " << _size << " at " << _gpu_ptr;
     logger.info(msg.str());
 }
 

--- a/src/debug_buffer.hpp
+++ b/src/debug_buffer.hpp
@@ -15,19 +15,20 @@ private:
     hsa_region_t _gpu_region;
     hsa_region_t _host_region;
     size_t _size;
+    size_t _hidden_size;
     void* _gpu_ptr;
     void* _host_ptr;
 
     static hsa_status_t iterate_memory_regions(hsa_region_t region, void* data);
 
 public:
-    DebugBuffer() : _size(0), _gpu_ptr{nullptr}, _host_ptr{nullptr} {}
-    DebugBuffer(hsa_agent_t agent, AgentLogger& logger, uint64_t size);
+    DebugBuffer() : _size(0), _hidden_size(0), _gpu_ptr{nullptr}, _host_ptr{nullptr} {}
+    DebugBuffer(hsa_agent_t agent, AgentLogger& logger, uint64_t buffer_size, uint64_t hidden_size);
     // Owns the buffer, should not be copied
     DebugBuffer(const DebugBuffer&) = delete;
 
     void write_to_file(AgentLogger& logger, const std::string& path);
-    size_t size() const { return _size; }
+    size_t debug_size() const { return _size - _hidden_size; }
     std::optional<size_t> gpu_buffer_address() const
     {
         if (_gpu_ptr)

--- a/tests/fixtures/breakpoint_trap.pl
+++ b/tests/fixtures/breakpoint_trap.pl
@@ -122,7 +122,7 @@ trap_handler:
   // sgprDbgStmp      = ttmp2
   // sgprDbgCounter   = ttmp4
   // sgprDbgSoff      = ttmp5
-  // sgprDbgDumpCount = ttmp7
+  // sgprDbgHiddenSoff= ttmp6
   // sgprDbgSrd       = [ttmp8, ttmp9, ttmp10, ttmp11]
   //  n_var           = $n_var
   //  vars            = $dump_vars
@@ -146,9 +146,9 @@ trap_1:
   v_readfirstlane_b32 ttmp4,  v0
   s_lshr_b32          ttmp4,  ttmp4, 6 //wave_size_log2
   s_add_u32           ttmp5,  ttmp5, ttmp4
-  s_mov_b32           ttmp7,  ttmp5
+  s_mov_b32           ttmp6,  ttmp5
   s_mul_i32           ttmp5,  ttmp5, 64 * (1 + $n_var) * 4
-  s_mul_i32           ttmp7,  ttmp7, 64 * (1) * 4
+  s_mul_i32           ttmp6,  ttmp6, 64 * (1) * 4
   s_mov_b32           ttmp4,  0
 
   s_branch            goto_skip_dump_instruction
@@ -160,7 +160,7 @@ $loopcounter
   s_mov_b32           ttmp12    , exec_lo
   s_mov_b32           ttmp13    , exec_hi
   s_mov_b64           exec      , -1
-  buffer_store_dword  v[vgprDbg], off, [ttmp8, ttmp9, ttmp10, ttmp11], ttmp7, offset:0  // save vgprDbg
+  buffer_store_dword  v[vgprDbg], off, [ttmp8, ttmp9, ttmp10, ttmp11], ttmp6, offset:0  // save vgprDbg to the hidden buffer
 
   m_init_buffer_debug_srd
   v_mov_b32           v[vgprDbg], 0x7777777
@@ -191,7 +191,7 @@ trap_3:
 
 trap_4:
   m_init_hidden_debug_srd
-  buffer_load_dword   v[vgprDbg], off, [ttmp8, ttmp9, ttmp10, ttmp11], ttmp7, offset:0
+  buffer_load_dword   v[vgprDbg], off, [ttmp8, ttmp9, ttmp10, ttmp11], ttmp6, offset:0  // restore vgprDbg value
   s_waitcnt           0
 
 trap_exit:

--- a/tests/fixtures/config.toml
+++ b/tests/fixtures/config.toml
@@ -3,6 +3,7 @@ log = "-"
 
 [debug-buffer]
 size = 1048576
+hidden-size = 4096
 dump-file = "tests/tmp/debug_buffer"
 
 [code-object-dump]
@@ -14,8 +15,8 @@ when-call-count = 1
 load-file = "tests/tmp/replacement.co"
 load-trap-handler-file = "tests/tmp/replacement.co"
 exec-before-load = """bash -o pipefail -c '\
-  perl tests/fixtures/breakpoint_trap.pl -ba $ASM_DBG_BUF_ADDR -bs $ASM_DBG_BUF_SIZE \
-      -w v[tid_dump] -l 36 -t 2 tests/kernels/dbg_kernel.s \
+  perl tests/fixtures/breakpoint_trap.pl -ba $ASM_DBG_BUF_ADDR -bs $ASM_DBG_BUF_SIZE -ha $ASM_HID_BUF_ADDR \
+      -w v[tid_dump] -e "s_nop 10" -l 37 -t 2 tests/kernels/dbg_kernel.s \
   | /opt/rocm/bin/hcc -x assembler -target amdgcn--amdhsa -mcpu=`/opt/rocm/bin/rocminfo | grep -om1 gfx9..` -mno-code-object-v3 \
     -Itests/kernels/include -o tests/tmp/replacement.co -'"""
 

--- a/tests/kernels/dbg_kernel.s
+++ b/tests/kernels/dbg_kernel.s
@@ -31,6 +31,7 @@ dbg_kernel:
   .end_amd_kernel_code_t
 
   v_mov_b32 v[tid_dump], v[tid]
+  v_add_lshl_u32  v0, v0, 1, 1
   s_mov_b32 s[counter],  0x0
   
 loop:

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -6,6 +6,7 @@ TEST_CASE("reads a valid configuration file", "[config]")
     agent::Config config;
     REQUIRE(config.agent_log_file() == "-");
     REQUIRE(config.debug_buffer_size() == 1048576);
+    REQUIRE(config.debug_hidden_buffer_size() == 4096);
     REQUIRE(config.debug_buffer_dump_file() == "tests/tmp/debug_buffer");
     REQUIRE(config.code_object_log_file() == "tests/tmp/co_dump.log");
     REQUIRE(config.code_object_dump_dir() == "tests/tmp/");
@@ -19,8 +20,8 @@ TEST_CASE("reads a valid configuration file", "[config]")
          .replacement_path = "tests/tmp/replacement.co",
          .trap_handler_path = "tests/tmp/replacement.co",
          .external_command = "bash -o pipefail -c '"
-                             "perl tests/fixtures/breakpoint_trap.pl -ba $ASM_DBG_BUF_ADDR -bs $ASM_DBG_BUF_SIZE "
-                             "-w v[tid_dump] -l 36 -t 2 tests/kernels/dbg_kernel.s | "
+                             "perl tests/fixtures/breakpoint_trap.pl -ba $ASM_DBG_BUF_ADDR -bs $ASM_DBG_BUF_SIZE -ha $ASM_HID_BUF_ADDR "
+                             "-w v[tid_dump] -e \"s_nop 10\" -l 37 -t 2 tests/kernels/dbg_kernel.s | "
                              "/opt/rocm/bin/hcc -x assembler -target amdgcn--amdhsa "
                              "-mcpu=`/opt/rocm/bin/rocminfo | grep -om1 gfx9..` -mno-code-object-v3 "
                              "-Itests/kernels/include -o tests/tmp/replacement.co -'"},

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -87,3 +87,32 @@ TEST_CASE("trap handler is properly set up with more then one group", "[integrat
         REQUIRE(dwords[1024 + dword_idx] == tid++); /* tid from gid = 1 */
     }
 }
+
+TEST_CASE("trap handler is properly set up with hidden buffer", "[integration]")
+{
+    system("rm -r tests/tmp; mkdir tests/tmp; cp build/tests/kernels/trap_handler.co tests/tmp");
+    {
+        KernelRunner runner;
+        runner.load_code_object("build/tests/kernels/dbg_kernel.co", "dbg_kernel");
+        runner.init_dispatch_packet(64, 128);
+        runner.dispatch_kernel();
+        runner.await_kernel_completion();
+    }
+
+    auto dwords = load_debug_buffer();
+    REQUIRE(dwords[0] == 0x7777777);
+    uint32_t tid = 0;
+    tid++;
+    for (uint32_t dword_idx = 1 /* skip system */; dword_idx < dwords.size() && tid < 64; dword_idx += 2 /* skip system */)
+    {
+        REQUIRE(dwords[dword_idx] == tid);          /* tid from gid = 0 */
+        REQUIRE(dwords[1024 + dword_idx] == tid++); /* tid from gid = 1 */
+    }
+
+    tid = 1;
+    for (uint32_t dword_idx = dwords.size() - 1024 /* skip debug buffer */; dword_idx < dwords.size() && tid < 64; dword_idx += 1)
+    {
+        REQUIRE(dwords[dword_idx] == 2 * tid);         /* saved value v[vgprDbg] from gid = 0 (equals tid)*/
+        REQUIRE(dwords[512 + dword_idx] == 2 * tid++); /* saved value v[vgprDbg] from gid = 1 (equals tid)*/
+    }
+}


### PR DESCRIPTION
The value of `v[vgprDbg]` is restore correctly. Also this value is saved to the `hidden buffer`.

Now now the config has the property `hidden-size` that describes the amount of additional memory for `hidden watches` like `v[vgprDbg]` or system variables. 
Also, when initializing the buffer, it is set `ASM_HID_BUF_ADDR` env variable with hidden buffer address

> buffer size = debug buffer size + hidden buffer size
> hidden buffer adderess = buffer address + debug buffer size

 